### PR TITLE
make 'makefile.inc' include optional

### DIFF
--- a/plugin-kismap/Makefile
+++ b/plugin-kismap/Makefile
@@ -5,7 +5,7 @@ PLUGIN_NAME ?= kismap
 KIS_SRC_DIR ?= /usr/src/kismet
 KIS_INC_DIR ?= $(KIS_SRC_DIR)
 
-include $(KIS_SRC_DIR)/Makefile.inc
+-include $(KIS_SRC_DIR)/Makefile.inc
 
 BLDHOME	= .
 top_builddir = $(BLDHOME)


### PR DESCRIPTION
In case they haven't symlinked the kismet src (and since kismet src isn't strictly needed)